### PR TITLE
Changed module file_helpers.rb to a class FileDataStore

### DIFF
--- a/lib/enigma_engine/engine.rb
+++ b/lib/enigma_engine/engine.rb
@@ -1,13 +1,11 @@
 require_relative 'rotors'
 require_relative 'offsets'
-require_relative 'file_helpers'
 require_relative 'date_key_helpers'
 
 module EnigmaEngine
   class Engine
     include Rotors
     include Offsets
-    include FileHelpers
     include DateKeyHelpers
 
     attr_writer :date, :key

--- a/lib/enigma_engine/file_helpers.rb
+++ b/lib/enigma_engine/file_helpers.rb
@@ -1,25 +1,22 @@
 module EnigmaEngine
-  module FileHelpers
-    def open_file(file_name)
-      file = File.open(file_name, 'r')
-      if File.exist? file
-        data = file.read
+  class FileDataStore
+    def open(file_name)
+      if File.exist? file_name
+        data = File.read file_name
         data.gsub(/\n/, ' ')
+      else
+        'Cannot find file, Run [enigma help] to see help!'
       end
-    rescue
-      raise <<NOTIFY
-"Cannot find file, Run [enigma help] to see help!"
-NOTIFY
     end
 
-    def create_write_file(txt, file_name, key, date, type = false)
+    def create(txt, file_name, key, date, type = false)
       file = File.open(file_name, 'w')
       file.write(txt)
       file.close
       show_msg(file_name, key, date, type)
     end
 
-    def text_to_array(text)
+    def to_array(text)
       text = text.split('').map(&:downcase)
       text.each_slice(4).to_a
     end
@@ -27,10 +24,7 @@ NOTIFY
     def show_msg(new_file, key, date, type = false)
       msg = 'Please take note of the key & date in order to decrypt this file'
       (type) ? msg = yellow(msg) : msg = ''
-      puts <<NOTIFY
-Created: #{green(new_file)}\nKey: #{red(key)}\nDate: #{blue(date)}
-#{msg}
-NOTIFY
+      "Created: #{green(new_file)}\nKey: #{red(key)}\nDate: #{blue(date)} #{msg}"
     end
   end
 end


### PR DESCRIPTION
Why?
This was done to avoid the unecessary use of mixins include in my engine
class.
The engine class was also modified because the file_helepers.rb is
included in the engine.rb file so changes must be made to ensure there
are no errors.